### PR TITLE
Fix typo

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ A fork from [[https://github.com/RickMoynihan/yasnippet-org-mode][RickMoynihan/y
 2. Copy and paste =snippets.org= as =<yas-snippet-dirs>/snippets.org=.
 3. Create =org-mode= directory under =<yas-snippet-dirs>=.
 4. Edit =snippets.org=.
-5. Tangle =snippets.org= by =M-x org-tangle-babel=.
+5. Tangle =snippets.org= by =M-x org-babel-tangle=.
 
 Then, snippets for org mode will be created in =<yas-snippet-dirs>/org-mode=.
 


### PR DESCRIPTION
やり方のところで、関数の名前がタイポされていたので修正しました。
(まねしようとして気付いた)